### PR TITLE
Revert "call linkdupdate on interface up/down"

### DIFF
--- a/jffs/bin/update
+++ b/jffs/bin/update
@@ -18,9 +18,6 @@ rm -f scripts.tar
 rm -f /jffs/etc/config/linkdupdate.ipup
 ln /jffs/scripts/wan/linkdupdate /jffs/etc/config/linkdupdate.ipup
 
-rm -f /jffs/etc/config/linkdupdate.if
-ln /jffs/scripts/wan/linkdupdate /jffs/etc/config/linkdupdate.if
-
 . /jffs/scripts/wan/global
 
 # set nvram vars


### PR DESCRIPTION
Reverts Kapral67/Dual-WAN#7

[No Longer In Source Code](https://wiki.dd-wrt.com/wiki/index.php/Script_Execution)